### PR TITLE
チェックボックスのデフォルトスタイルが無効になったのでもとに戻す

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -5977,6 +5977,12 @@ input[type="submit"],
 	background-color: #315bc2;
 }
 
+input[type="checkbox"] {
+	appearance: checkbox;
+	-moz-appearance: checkbox;
+	-webkit-appearance: checkbox;
+}
+
 .primary-menu a,
 .entry-categories a {
 	color: #315bc2 !important;

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -286,6 +286,12 @@ input[type="submit"],
 	background-color: $primary;
 }
 
+input[type="checkbox"] {
+	appearance: checkbox;
+	-moz-appearance: checkbox;
+	-webkit-appearance: checkbox;
+}
+
 .primary-menu a,
 .entry-categories a {
 	color: $primary !important;


### PR DESCRIPTION
フォームのチェックボックスが選択できないバグがありました。
Twenty Twenty のCSSでデフォルトスタイルがnoneになっていたので、checkbox形式に戻す記述を追加しました。